### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/advantic-au/libmqm-sys/compare/v0.5.0...v0.6.0) - 2024-12-03
+
+### Other
+
+- docsrs targets ([#31](https://github.com/advantic-au/libmqm-sys/pull/31))
+- Enable doctests in CI ([#30](https://github.com/advantic-au/libmqm-sys/pull/30))
+- Workspace CI ([#24](https://github.com/advantic-au/libmqm-sys/pull/24))
+- version prege
+- Support MQCD_CLIENT_CONN_DEFAULT
+- * all defaults available from package
+- Added MQIEP default
+- Merge remote-tracking branch 'origin/develop' into workspace
+- workspace progress
+- libmqm-default
+- Moved libmqm-sys to sub folder
+- Documentation improvements ([#22](https://github.com/advantic-au/libmqm-sys/pull/22))
+- Added MQ library to release-plz release command ([#29](https://github.com/advantic-au/libmqm-sys/pull/29))
+- explicit versions for publishing ([#28](https://github.com/advantic-au/libmqm-sys/pull/28))
+- pregen refresh ([#25](https://github.com/advantic-au/libmqm-sys/pull/25))
+- const default progress
+- release v0.5.0 ([#19](https://github.com/advantic-au/libmqm-sys/pull/19))
+- minor documentation updates ([#16](https://github.com/advantic-au/libmqm-sys/pull/16))
+- Minor readme fixes
+- Minor readme updates and expect reasons.
+- Identifier naming cleanup
+- Version 0.4.0
+- MacOS support
+- IBM MQ 9.4 - Linux bindgen
+- Added badges
+- Bump version
+- Document major additional feature flags
+- Bump version
+- README formatting
+- MQCBC structure.
+- Address linting of README
+- Improved build script and windows support
+- Example successfully compiles
+- First draft of the libmqm-sys crate
+
 ## [0.5.0](https://github.com/advantic-au/libmqm-sys/compare/v0.4.0...v0.5.0) - 2024-10-28
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,40 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- docsrs targets ([#31](https://github.com/advantic-au/libmqm-sys/pull/31))
-- Enable doctests in CI ([#30](https://github.com/advantic-au/libmqm-sys/pull/30))
-- Workspace CI ([#24](https://github.com/advantic-au/libmqm-sys/pull/24))
-- version prege
-- Support MQCD_CLIENT_CONN_DEFAULT
-- * all defaults available from package
-- Added MQIEP default
-- Merge remote-tracking branch 'origin/develop' into workspace
-- workspace progress
-- libmqm-default
-- Moved libmqm-sys to sub folder
-- Documentation improvements ([#22](https://github.com/advantic-au/libmqm-sys/pull/22))
-- Added MQ library to release-plz release command ([#29](https://github.com/advantic-au/libmqm-sys/pull/29))
-- explicit versions for publishing ([#28](https://github.com/advantic-au/libmqm-sys/pull/28))
-- pregen refresh ([#25](https://github.com/advantic-au/libmqm-sys/pull/25))
-- const default progress
-- release v0.5.0 ([#19](https://github.com/advantic-au/libmqm-sys/pull/19))
-- minor documentation updates ([#16](https://github.com/advantic-au/libmqm-sys/pull/16))
-- Minor readme fixes
-- Minor readme updates and expect reasons.
-- Identifier naming cleanup
-- Version 0.4.0
-- MacOS support
-- IBM MQ 9.4 - Linux bindgen
-- Added badges
-- Bump version
-- Document major additional feature flags
-- Bump version
-- README formatting
-- MQCBC structure.
-- Address linting of README
-- Improved build script and windows support
-- Example successfully compiles
-- First draft of the libmqm-sys crate
+- Added libmqm_default package to publish MQ structure constants
+- Added missing MQI and MQAI functions
+- Added some documentation and doctests
+- Exposes compiled version constants
 
 ## [0.5.0](https://github.com/advantic-au/libmqm-sys/compare/v0.4.0...v0.5.0) - 2024-10-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["libmqm-default", "libmqm-sys"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Warren Spits <warren@advantic.au>"]
 repository = "https://github.com/advantic-au/libmqm-sys"
 license = "Apache-2.0"

--- a/libmqm-default/Cargo.toml
+++ b/libmqm-default/Cargo.toml
@@ -13,10 +13,10 @@ rust-version.workspace = true
 build = "build/main.rs"
 
 [dependencies]
-libmqm-sys = { version = "0.5", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.6", path = "../libmqm-sys", default-features = false }
 
 [build-dependencies]
-libmqm-sys = { version = "0.5", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.6", path = "../libmqm-sys", default-features = false }
 prettyplease = { version = "0.2.25", optional = true }
 syn = { version = "2.0.90", optional = true, default-features = false, features = [
     "full",


### PR DESCRIPTION
## 🤖 New release
* `libmqm-default`: 0.5.0 -> 0.6.0
* `libmqm-sys`: 0.5.0 -> 0.6.0 (⚠️ API breaking changes)

### ⚠️ `libmqm-sys` breaking changes

```
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/module_missing.ron

Failed in:
  mod libmqm_sys::default, previously in file /tmp/.tmpCKdsyY/libmqm-sys/src/default.rs:1
  mod libmqm_sys::function, previously in file /tmp/.tmpCKdsyY/libmqm-sys/src/function.rs:1

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_method_added.ron

Failed in:
  trait method libmqm_sys::Mqai::mqBagToBuffer in file /tmp/.tmppVb8kh/libmqm-sys/libmqm-sys/src/function.rs:850
  trait method libmqm_sys::Mqai::mqBufferToBag in file /tmp/.tmppVb8kh/libmqm-sys/libmqm-sys/src/function.rs:865
  trait method libmqm_sys::Mqai::mqInquireItemInfo in file /tmp/.tmppVb8kh/libmqm-sys/libmqm-sys/src/function.rs:879

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_missing.ron

Failed in:
  trait libmqm_sys::function::Mqai, previously in file /tmp/.tmpCKdsyY/libmqm-sys/src/function.rs:252
  trait libmqm_sys::function::Mqi, previously in file /tmp/.tmpCKdsyY/libmqm-sys/src/function.rs:5
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libmqm-sys`
<blockquote>

## [0.6.0](https://github.com/advantic-au/libmqm-sys/compare/v0.5.0...v0.6.0) - 2024-12-03

### Other

- docsrs targets ([#31](https://github.com/advantic-au/libmqm-sys/pull/31))
- Enable doctests in CI ([#30](https://github.com/advantic-au/libmqm-sys/pull/30))
- Workspace CI ([#24](https://github.com/advantic-au/libmqm-sys/pull/24))
- version prege
- Support MQCD_CLIENT_CONN_DEFAULT
- * all defaults available from package
- Added MQIEP default
- Merge remote-tracking branch 'origin/develop' into workspace
- workspace progress
- libmqm-default
- Moved libmqm-sys to sub folder
- Documentation improvements ([#22](https://github.com/advantic-au/libmqm-sys/pull/22))
- Added MQ library to release-plz release command ([#29](https://github.com/advantic-au/libmqm-sys/pull/29))
- explicit versions for publishing ([#28](https://github.com/advantic-au/libmqm-sys/pull/28))
- pregen refresh ([#25](https://github.com/advantic-au/libmqm-sys/pull/25))
- const default progress
- release v0.5.0 ([#19](https://github.com/advantic-au/libmqm-sys/pull/19))
- minor documentation updates ([#16](https://github.com/advantic-au/libmqm-sys/pull/16))
- Minor readme fixes
- Minor readme updates and expect reasons.
- Identifier naming cleanup
- Version 0.4.0
- MacOS support
- IBM MQ 9.4 - Linux bindgen
- Added badges
- Bump version
- Document major additional feature flags
- Bump version
- README formatting
- MQCBC structure.
- Address linting of README
- Improved build script and windows support
- Example successfully compiles
- First draft of the libmqm-sys crate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).