### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/advantic-au/libmqm-sys/compare/v0.6.0...v0.6.1) - 2024-12-03
+
+### Other
+
+- release v0.6.0
+- docsrs targets ([#31](https://github.com/advantic-au/libmqm-sys/pull/31))
+- Added MQ library to release-plz release command ([#29](https://github.com/advantic-au/libmqm-sys/pull/29))
+- explicit versions for publishing ([#28](https://github.com/advantic-au/libmqm-sys/pull/28))
+- pregen refresh ([#25](https://github.com/advantic-au/libmqm-sys/pull/25))
+- Workspace CI ([#24](https://github.com/advantic-au/libmqm-sys/pull/24))
+- version prege
+- Support MQCD_CLIENT_CONN_DEFAULT
+- * all defaults available from package
+- const default progress
+- workspace progress
+- libmqm-default
+- Documentation improvements ([#22](https://github.com/advantic-au/libmqm-sys/pull/22))
+- release v0.5.0 ([#19](https://github.com/advantic-au/libmqm-sys/pull/19))
+- minor documentation updates ([#16](https://github.com/advantic-au/libmqm-sys/pull/16))
+- Minor readme fixes
+- Minor readme updates and expect reasons.
+- Identifier naming cleanup
+- Version 0.4.0
+- MacOS support
+- IBM MQ 9.4 - Linux bindgen
+- Added badges
+- Bump version
+- Document major additional feature flags
+- Bump version
+- README formatting
+- MQCBC structure.
+- Address linting of README
+- Improved build script and windows support
+- Example successfully compiles
+- First draft of the libmqm-sys crate
+
 ## [0.6.0](https://github.com/advantic-au/libmqm-sys/compare/v0.5.0...v0.6.0) - 2024-12-03
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["libmqm-default", "libmqm-sys"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Warren Spits <warren@advantic.au>"]
 repository = "https://github.com/advantic-au/libmqm-sys"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `libmqm-default`: 0.6.0 -> 0.6.1
* `libmqm-sys`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `libmqm-sys`
<blockquote>

## [0.6.1](https://github.com/advantic-au/libmqm-sys/compare/v0.6.0...v0.6.1) - 2024-12-03

### Other

- release v0.6.0
- docsrs targets ([#31](https://github.com/advantic-au/libmqm-sys/pull/31))
- Added MQ library to release-plz release command ([#29](https://github.com/advantic-au/libmqm-sys/pull/29))
- explicit versions for publishing ([#28](https://github.com/advantic-au/libmqm-sys/pull/28))
- pregen refresh ([#25](https://github.com/advantic-au/libmqm-sys/pull/25))
- Workspace CI ([#24](https://github.com/advantic-au/libmqm-sys/pull/24))
- version prege
- Support MQCD_CLIENT_CONN_DEFAULT
- * all defaults available from package
- const default progress
- workspace progress
- libmqm-default
- Documentation improvements ([#22](https://github.com/advantic-au/libmqm-sys/pull/22))
- release v0.5.0 ([#19](https://github.com/advantic-au/libmqm-sys/pull/19))
- minor documentation updates ([#16](https://github.com/advantic-au/libmqm-sys/pull/16))
- Minor readme fixes
- Minor readme updates and expect reasons.
- Identifier naming cleanup
- Version 0.4.0
- MacOS support
- IBM MQ 9.4 - Linux bindgen
- Added badges
- Bump version
- Document major additional feature flags
- Bump version
- README formatting
- MQCBC structure.
- Address linting of README
- Improved build script and windows support
- Example successfully compiles
- First draft of the libmqm-sys crate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).