### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0](https://github.com/advantic-au/libmqm-sys/compare/v0.6.0...v0.7.0) - 2025-03-26
 
-### Fixed
-
-- pregen command commit comment and pretty please minimum version
-
 ### Other
 
 - IBM MQ client 9.4.2 ([#60](https://github.com/advantic-au/libmqm-sys/pull/60))
-- default pregen fixes ([#45](https://github.com/advantic-au/libmqm-sys/pull/45))
-- MQ client 9.4.1.1 Linux
-- MQ client 9.4.1.1 Windows
-- MQ client 9.4.1.0 macOS
-- MQ client 9.4.1.0 Linux
-- MQ client 9.4.1.0 Windows
+
 - MQC 9.4.1.1
 
 ## [0.6.0](https://github.com/advantic-au/libmqm-sys/compare/v0.5.0...v0.6.0) - 2024-12-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/advantic-au/libmqm-sys/compare/v0.6.0...v0.7.0) - 2025-03-26
+
+### Fixed
+
+- pregen command commit comment and pretty please minimum version
+
+### Other
+
+- IBM MQ client 9.4.2 ([#60](https://github.com/advantic-au/libmqm-sys/pull/60))
+- default pregen fixes ([#45](https://github.com/advantic-au/libmqm-sys/pull/45))
+- MQ client 9.4.1.1 Linux
+- MQ client 9.4.1.1 Windows
+- MQ client 9.4.1.0 macOS
+- MQ client 9.4.1.0 Linux
+- MQ client 9.4.1.0 Windows
+- MQC 9.4.1.1
+
 ## [0.6.0](https://github.com/advantic-au/libmqm-sys/compare/v0.5.0...v0.6.0) - 2024-12-03
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["libmqm-default", "libmqm-sys"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Warren Spits <warren@advantic.au>"]
 repository = "https://github.com/advantic-au/libmqm-sys"
 license = "Apache-2.0"

--- a/libmqm-default/Cargo.toml
+++ b/libmqm-default/Cargo.toml
@@ -13,10 +13,10 @@ rust-version.workspace = true
 build = "build/main.rs"
 
 [dependencies]
-libmqm-sys = { version = "0.6", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.7", path = "../libmqm-sys", default-features = false }
 
 [build-dependencies]
-libmqm-sys = { version = "0.6", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.7", path = "../libmqm-sys", default-features = false }
 prettyplease = { version = "0.2.31", optional = true }
 syn = { version = "2.0.90", optional = true, default-features = false, features = [
     "full",


### PR DESCRIPTION



## 🤖 New release

* `libmqm-sys`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `libmqm-default`: 0.6.0 -> 0.7.0 (✓ API compatible changes)

### ⚠ `libmqm-sys` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/feature_missing.ron

Failed in:
  feature mqc_9_3_0_5 in the package's Cargo.toml
  feature mqc_9_2_0_16 in the package's Cargo.toml
  feature mqc_9_2_0_21 in the package's Cargo.toml
  feature mqc_9_2_0_5 in the package's Cargo.toml
  feature mqc_9_3_2_1 in the package's Cargo.toml
  feature mqc_9_3_0_1 in the package's Cargo.toml
  feature mqc_9_4_0_5 in the package's Cargo.toml
  feature mqc_9_2_0_28 in the package's Cargo.toml
  feature mqc_9_2_0_10 in the package's Cargo.toml
  feature mqc_9_2_0_22 in the package's Cargo.toml
  feature mqc_9_2_0_15 in the package's Cargo.toml
  feature mqc_9_3_3_1 in the package's Cargo.toml
  feature mqc_9_2_0_25 in the package's Cargo.toml
  feature mqc_9_3_0_11 in the package's Cargo.toml
  feature mqc_9_3_0_4 in the package's Cargo.toml
  feature mqc_9_3_0_6 in the package's Cargo.toml
  feature mqc_9_3_0_20 in the package's Cargo.toml
  feature mqc_9_4_0_6 in the package's Cargo.toml
  feature mqc_9_3_0_17 in the package's Cargo.toml
  feature mqc_9_3_4_1 in the package's Cargo.toml
  feature mqc_9_3_0_15 in the package's Cargo.toml
  feature mqc_9_3_0_10 in the package's Cargo.toml
  feature mqc_9_2_0_27 in the package's Cargo.toml
  feature mqc_9_2_0_11 in the package's Cargo.toml
  feature mqc_9_3_0_16 in the package's Cargo.toml
  feature mqc_9_2_0_20 in the package's Cargo.toml
  feature mqc_9_2_0_6 in the package's Cargo.toml
  feature mqc_9_2_0_7 in the package's Cargo.toml
  feature mqc_9_3_5_1 in the package's Cargo.toml
  feature mqc_9_3_0_21 in the package's Cargo.toml
  feature mqc_9_2_0_26 in the package's Cargo.toml
  feature mqc_9_3_0_25 in the package's Cargo.toml
  feature mqc_9_3_0_2 in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libmqm-sys`

<blockquote>

## [0.7.0](https://github.com/advantic-au/libmqm-sys/compare/v0.6.0...v0.7.0) - 2025-03-26

### Fixed

- pregen command commit comment and pretty please minimum version

### Other

- IBM MQ client 9.4.2 ([#60](https://github.com/advantic-au/libmqm-sys/pull/60))
- default pregen fixes ([#45](https://github.com/advantic-au/libmqm-sys/pull/45))
- MQ client 9.4.1.1 Linux
- MQ client 9.4.1.1 Windows
- MQ client 9.4.1.0 macOS
- MQ client 9.4.1.0 Linux
- MQ client 9.4.1.0 Windows
- MQC 9.4.1.1
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).