### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,19 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Release version alignment for libmqm-default and libmqm-sys
-- Feature CI checks ([#110](https://github.com/advantic-au/libmqm-sys/pull/110))
 - MQ 9.4.3.0 ([#103](https://github.com/advantic-au/libmqm-sys/pull/103))
 - Rustify doc comments ([#109](https://github.com/advantic-au/libmqm-sys/pull/109))
 - Pregen build improvements ([#97](https://github.com/advantic-au/libmqm-sys/pull/97))
-- Improved README content
-- prettyplease bindgen formatting
 - constant lookup feature for libmqm-sys ([#94](https://github.com/advantic-au/libmqm-sys/pull/94))
-- s390x and powerpc64 pregen ([#91](https://github.com/advantic-au/libmqm-sys/pull/91))
 - s390x and powerpc64 support ([#90](https://github.com/advantic-au/libmqm-sys/pull/90))
-- pregen for aarch64 ([#84](https://github.com/advantic-au/libmqm-sys/pull/84))
 - Linux aarch64 ([#83](https://github.com/advantic-au/libmqm-sys/pull/83))
 - Rust 1.82 and Bindgen upgrade ([#81](https://github.com/advantic-au/libmqm-sys/pull/81))
-- precise version of libmqm-sys specified
 
 ## [0.8.0](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.7.0...libmqm-sys-v0.8.0) - 2025-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.8.0...libmqm-sys-v0.9.0) - 2025-06-27
+
+### Added
+
+- bitflags enhancements ([#80](https://github.com/advantic-au/libmqm-sys/pull/80))
+
+### Other
+
+- Release version alignment for libmqm-default and libmqm-sys
+- Feature CI checks ([#110](https://github.com/advantic-au/libmqm-sys/pull/110))
+- MQ 9.4.3.0 ([#103](https://github.com/advantic-au/libmqm-sys/pull/103))
+- Rustify doc comments ([#109](https://github.com/advantic-au/libmqm-sys/pull/109))
+- Pregen build improvements ([#97](https://github.com/advantic-au/libmqm-sys/pull/97))
+- Improved README content
+- prettyplease bindgen formatting
+- constant lookup feature for libmqm-sys ([#94](https://github.com/advantic-au/libmqm-sys/pull/94))
+- s390x and powerpc64 pregen ([#91](https://github.com/advantic-au/libmqm-sys/pull/91))
+- s390x and powerpc64 support ([#90](https://github.com/advantic-au/libmqm-sys/pull/90))
+- pregen for aarch64 ([#84](https://github.com/advantic-au/libmqm-sys/pull/84))
+- Linux aarch64 ([#83](https://github.com/advantic-au/libmqm-sys/pull/83))
+- Rust 1.82 and Bindgen upgrade ([#81](https://github.com/advantic-au/libmqm-sys/pull/81))
+- precise version of libmqm-sys specified
+
 ## [0.8.0](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.7.0...libmqm-sys-v0.8.0) - 2025-04-24
 
 ### Other

--- a/libmqm-constants/Cargo.toml
+++ b/libmqm-constants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-constants"
-version = "0.8.0"
+version = "0.8.1"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) constant definitions"
 categories = ["external-ffi-bindings", "asynchronous"]
 authors.workspace = true
@@ -72,7 +72,7 @@ mqc_9_4_2_0 = ["libmqm-sys/mqc_9_4_2_0", "mqc_9_4_1_0"]
 mqc_9_4_3_0 = ["libmqm-sys/mqc_9_4_3_0", "mqc_9_4_2_0"]
 
 [dependencies]
-libmqm-sys = { version = "0.8.0", default-features = false, path = "../libmqm-sys" }
+libmqm-sys = { version = "0.9.0", default-features = false, path = "../libmqm-sys" }
 phf = { default-features = false, version = "0.12.1" }
 derive_more = { version = "2.0.1", features = [
     "from",
@@ -83,7 +83,7 @@ derive_more = { version = "2.0.1", features = [
 document-features = { version = "0.2.10", optional = true }
 
 [build-dependencies]
-libmqm-sys = { version = "0.8.0", default-features = false, path = "../libmqm-sys" }
+libmqm-sys = { version = "0.9.0", default-features = false, path = "../libmqm-sys" }
 regex-lite = { version = "0.1.6", optional = true }
 phf_codegen = { version = "0.12.1", optional = true }
 phf_generator = { version = "0.12.1", optional = true }

--- a/libmqm-default/Cargo.toml
+++ b/libmqm-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-default"
-version = "0.8.0"
+version = "0.9.0"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) structure defaults"
 keywords = ["message-queue", "messaging"]
 categories = ["external-ffi-bindings", "asynchronous"]
@@ -12,11 +12,11 @@ rust-version.workspace = true
 build = "build/main.rs"
 
 [dependencies]
-libmqm-sys = { version = "0.8.0", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.9.0", path = "../libmqm-sys", default-features = false }
 document-features = { version = "0.2.10", optional = true }
 
 [build-dependencies]
-libmqm-sys = { version = "0.8.0", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.9.0", path = "../libmqm-sys", default-features = false }
 prettyplease = { version = "0.2.31", optional = true }
 syn = { version = "2.0.90", optional = true, default-features = false, features = [
     "full",

--- a/libmqm-sys/Cargo.toml
+++ b/libmqm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-sys"
-version = "0.8.0"
+version = "0.9.0"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) bindings"
 keywords = ["message-queue", "messaging"]
 categories = ["external-ffi-bindings", "asynchronous"]


### PR DESCRIPTION



## 🤖 New release

* `libmqm-sys`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `libmqm-constants`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `libmqm-default`: 0.8.0 -> 0.9.0 (✓ API compatible changes)

### ⚠ `libmqm-sys` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/feature_missing.ron

Failed in:
  feature mqi_helpers in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function libmqm_sys::lib::MQSCO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10078
  function libmqm_sys::lib::MQBNO_OPTIONS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9824
  function libmqm_sys::lib::MQXEPO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10151
  function libmqm_sys::lib::MQCS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9897
  function libmqm_sys::lib::MQMCAT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9970
  function libmqm_sys::lib::MQQMF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10043
  function libmqm_sys::lib::MQTA_SUB_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10116
  function libmqm_sys::lib::MQCHIDS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9862
  function libmqm_sys::lib::MQHM_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9935
  function libmqm_sys::lib::MQOO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10008
  function libmqm_sys::lib::MQSECITEM_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10081
  function libmqm_sys::lib::MQBPLOCATION_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9827
  function libmqm_sys::lib::MQXPT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10154
  function libmqm_sys::lib::MQCUOWC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9900
  function libmqm_sys::lib::MQMCP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9973
  function libmqm_sys::lib::MQQMT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10046
  function libmqm_sys::lib::MQTC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10119
  function libmqm_sys::lib::MQCHLD_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9865
  function libmqm_sys::lib::MQIACF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9938
  function libmqm_sys::lib::MQOP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10011
  function libmqm_sys::lib::MQSECTYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10084
  function libmqm_sys::lib::MQCACH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9830
  function libmqm_sys::lib::MQXT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10157
  function libmqm_sys::lib::MQDELO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9903
  function libmqm_sys::lib::MQMDS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9976
  function libmqm_sys::lib::MQQSGS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10049
  function libmqm_sys::lib::MQTRAXSTR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10122
  function libmqm_sys::lib::MQCHSR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9868
  function libmqm_sys::lib::MQIAMO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9941
  function libmqm_sys::lib::MQOT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10014
  function libmqm_sys::lib::MQSEL_ANY_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10087
  function libmqm_sys::lib::MQCAMO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9833
  function libmqm_sys::lib::MQZAT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10160
  function libmqm_sys::lib::MQDLV_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9906
  function libmqm_sys::lib::MQMEDIMGSCHED_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9979
  function libmqm_sys::lib::MQQSO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10052
  function libmqm_sys::lib::MQTT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10125
  function libmqm_sys::lib::MQCHTAB_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9871
  function libmqm_sys::lib::MQIASY_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9944
  function libmqm_sys::lib::MQPD_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10017
  function libmqm_sys::lib::MQSPL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10090
  function libmqm_sys::lib::MQCA_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9836
  function libmqm_sys::lib::MQZID_NAME_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10163
  function libmqm_sys::lib::MQDMPO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9909
  function libmqm_sys::lib::MQMLP_ENCRYPTION_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9982
  function libmqm_sys::lib::MQRAR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10055
  function libmqm_sys::lib::MQACTP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9801
  function libmqm_sys::lib::MQUIDSUPP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10128
  function libmqm_sys::lib::MQCIT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9874
  function libmqm_sys::lib::MQIDO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9947
  function libmqm_sys::lib::MQPMO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10020
  function libmqm_sys::lib::MQSRO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10093
  function libmqm_sys::lib::MQCBDO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9839
  function libmqm_sys::lib::MQZIO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10166
  function libmqm_sys::lib::MQDSB_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9912
  function libmqm_sys::lib::MQMMBI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9985
  function libmqm_sys::lib::MQRCVTIME_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10058
  function libmqm_sys::lib::MQADOPT_CHECK_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9804
  function libmqm_sys::lib::MQUOWT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10131
  function libmqm_sys::lib::MQCLRS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9877
  function libmqm_sys::lib::MQIGQ_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9950
  function libmqm_sys::lib::MQPRI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10023
  function libmqm_sys::lib::MQSTAT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10096
  function libmqm_sys::lib::MQCBT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9842
  function libmqm_sys::lib::MQZTO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10169
  function libmqm_sys::lib::MQEI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9915
  function libmqm_sys::lib::MQMON_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9988
  function libmqm_sys::lib::MQRD_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10061
  function libmqm_sys::lib::MQAIT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9807
  function libmqm_sys::lib::MQUSAGE_PS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10134
  function libmqm_sys::lib::MQCLT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9880
  function libmqm_sys::lib::MQIMMREASON_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9953
  function libmqm_sys::lib::MQPRT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10026
  function libmqm_sys::lib::MQSUBTYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10099
  function libmqm_sys::lib::MQCC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9845
  function libmqm_sys::lib::MQ_HTTPSCERTVAL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10172
  function libmqm_sys::lib::MQET_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9918
  function libmqm_sys::lib::MQMT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9991
  function libmqm_sys::lib::MQRECORDING_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10064
  function libmqm_sys::lib::MQAT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9810
  function libmqm_sys::lib::MQUSRC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10137
  function libmqm_sys::lib::MQCMDI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9883
  function libmqm_sys::lib::MQIND_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9956
  function libmqm_sys::lib::MQPSM_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10029
  function libmqm_sys::lib::MQSUS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10102
  function libmqm_sys::lib::MQCFACCESS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9848
  function libmqm_sys::lib::MQEXPI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9921
  function libmqm_sys::lib::MQNHABACKLOG_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9994
  function libmqm_sys::lib::MQRFH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10067
  function libmqm_sys::lib::MQAUTHOPT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9813
  function libmqm_sys::lib::MQVS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10140
  function libmqm_sys::lib::MQCMHO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9886
  function libmqm_sys::lib::MQIT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9959
  function libmqm_sys::lib::MQPS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10032
  function libmqm_sys::lib::MQSVC_TYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10105
  function libmqm_sys::lib::MQCFOFFLD_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9851
  function libmqm_sys::lib::MQFB_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9924
  function libmqm_sys::lib::MQNHAGRPROLE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9997
  function libmqm_sys::lib::MQROUTE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10070
  function libmqm_sys::lib::MQAUTO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9816
  function libmqm_sys::lib::MQWIH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10143
  function libmqm_sys::lib::MQCOMPRESS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9889
  function libmqm_sys::lib::MQLDAPC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9962
  function libmqm_sys::lib::MQQA_GET_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10035
  function libmqm_sys::lib::MQSYSP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10108
  function libmqm_sys::lib::MQCFO_REMOVE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9854
  function libmqm_sys::lib::MQFS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9927
  function libmqm_sys::lib::MQNHASTATUS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10000
  function libmqm_sys::lib::MQRQ_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10073
  function libmqm_sys::lib::MQBALSTATE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9819
  function libmqm_sys::lib::MQWXP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10146
  function libmqm_sys::lib::MQCQT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9892
  function libmqm_sys::lib::MQLOGTYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9965
  function libmqm_sys::lib::MQQDT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10038
  function libmqm_sys::lib::MQS_OPENMODE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10111
  function libmqm_sys::lib::MQCFTYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9857
  function libmqm_sys::lib::MQGMO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9930
  function libmqm_sys::lib::MQNPM_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10003
  function libmqm_sys::lib::MQSCA_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10076
  function libmqm_sys::lib::MQBND_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9822
  function libmqm_sys::lib::MQXC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10149
  function libmqm_sys::lib::MQCSRV_CONVERT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9895
  function libmqm_sys::lib::MQMATCH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9968
  function libmqm_sys::lib::MQQMDT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10041
  function libmqm_sys::lib::MQTA_PROXY_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10114
  function libmqm_sys::lib::MQCGWI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9860
  function libmqm_sys::lib::MQHB_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9933
  function libmqm_sys::lib::MQOL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10006
  function libmqm_sys::lib::MQSCYC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10079
  function libmqm_sys::lib::MQBNO_TIMEOUT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9825
  function libmqm_sys::lib::MQXE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10152
  function libmqm_sys::lib::MQCTES_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9898
  function libmqm_sys::lib::MQMCB_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9971
  function libmqm_sys::lib::MQQMOPT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10044
  function libmqm_sys::lib::MQTCPKEEP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10117
  function libmqm_sys::lib::MQCHK_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9863
  function libmqm_sys::lib::MQHO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9936
  function libmqm_sys::lib::MQOPER_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10009
  function libmqm_sys::lib::MQSECPROT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10082
  function libmqm_sys::lib::MQBT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9828
  function libmqm_sys::lib::MQXR2_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10155
  function libmqm_sys::lib::MQDCC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9901
  function libmqm_sys::lib::MQMC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9974
  function libmqm_sys::lib::MQQO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10047
  function libmqm_sys::lib::MQTIME_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10120
  function libmqm_sys::lib::MQCHRR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9866
  function libmqm_sys::lib::MQIACH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9939
  function libmqm_sys::lib::MQOTEL_PCTL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10012
  function libmqm_sys::lib::MQSELTYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10085
  function libmqm_sys::lib::MQCADSD_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9831
  function libmqm_sys::lib::MQZAET_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10158
  function libmqm_sys::lib::MQDHF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9904
  function libmqm_sys::lib::MQMEDIMGINTVL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9977
  function libmqm_sys::lib::MQQSIE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10050
  function libmqm_sys::lib::MQTRIGGER_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10123
  function libmqm_sys::lib::MQCHSSTATE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9869
  function libmqm_sys::lib::MQIAMO_MONITOR_DATATYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9942
  function libmqm_sys::lib::MQPAGECLAS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10015
  function libmqm_sys::lib::MQSMPO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10088
  function libmqm_sys::lib::MQCAP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9834
  function libmqm_sys::lib::MQZCI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10161
  function libmqm_sys::lib::MQDL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9907
  function libmqm_sys::lib::MQMF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9980
  function libmqm_sys::lib::MQQSUM_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10053
  function libmqm_sys::lib::MQACTIVE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9800
  function libmqm_sys::lib::MQTYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10126
  function libmqm_sys::lib::MQCHT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9872
  function libmqm_sys::lib::MQIAV_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9945
  function libmqm_sys::lib::MQPER_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10018
  function libmqm_sys::lib::MQSP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10091
  function libmqm_sys::lib::MQCBCF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9837
  function libmqm_sys::lib::MQZID_USERID_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10164
  function libmqm_sys::lib::MQDNSWLM_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9910
  function libmqm_sys::lib::MQMLP_SIGN_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9983
  function libmqm_sys::lib::MQRCCF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10056
  function libmqm_sys::lib::MQACTV_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9802
  function libmqm_sys::lib::MQUNDELIVERED_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10129
  function libmqm_sys::lib::MQCLCT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9875
  function libmqm_sys::lib::MQIEPF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9948
  function libmqm_sys::lib::MQPMRF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10021
  function libmqm_sys::lib::MQSR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10094
  function libmqm_sys::lib::MQCBD_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9840
  function libmqm_sys::lib::MQZSE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10167
  function libmqm_sys::lib::MQDSE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9913
  function libmqm_sys::lib::MQMODE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9986
  function libmqm_sys::lib::MQRC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10059
  function libmqm_sys::lib::MQADOPT_TYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9805
  function libmqm_sys::lib::MQUSAGE_DS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10132
  function libmqm_sys::lib::MQCLRT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9878
  function libmqm_sys::lib::MQIIH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9951
  function libmqm_sys::lib::MQPROP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10024
  function libmqm_sys::lib::MQSTDBY_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10097
  function libmqm_sys::lib::MQCCSI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9843
  function libmqm_sys::lib::MQ_CERT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10170
  function libmqm_sys::lib::MQENC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9916
  function libmqm_sys::lib::MQMON_AVAILABILITY_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9989
  function libmqm_sys::lib::MQREADA_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10062
  function libmqm_sys::lib::MQAPPL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9808
  function libmqm_sys::lib::MQUSAGE_SMDS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10135
  function libmqm_sys::lib::MQCLWL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9881
  function libmqm_sys::lib::MQIMPO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9954
  function libmqm_sys::lib::MQPSCLUS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10027
  function libmqm_sys::lib::MQSUB_DURABILITY_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10100
  function libmqm_sys::lib::MQCDC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9846
  function libmqm_sys::lib::MQ_MQTT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10173
  function libmqm_sys::lib::MQEVO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9919
  function libmqm_sys::lib::MQMULC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9992
  function libmqm_sys::lib::MQREGO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10065
  function libmqm_sys::lib::MQAUSC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9811
  function libmqm_sys::lib::MQUS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10138
  function libmqm_sys::lib::MQCMDL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9884
  function libmqm_sys::lib::MQIPADDR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9957
  function libmqm_sys::lib::MQPSPROP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10030
  function libmqm_sys::lib::MQSVC_CONTROL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10103
  function libmqm_sys::lib::MQCFCONLOS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9849
  function libmqm_sys::lib::MQEXTATTRS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9922
  function libmqm_sys::lib::MQNHACONNACTV_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9995
  function libmqm_sys::lib::MQRL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10068
  function libmqm_sys::lib::MQAUTH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9814
  function libmqm_sys::lib::MQVU_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10141
  function libmqm_sys::lib::MQCNO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9887
  function libmqm_sys::lib::MQKAI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9960
  function libmqm_sys::lib::MQPUBO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10033
  function libmqm_sys::lib::MQSYNCPOINT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10106
  function libmqm_sys::lib::MQCFOP_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9852
  function libmqm_sys::lib::MQFC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9925
  function libmqm_sys::lib::MQNHAINSYNC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9998
  function libmqm_sys::lib::MQRO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10071
  function libmqm_sys::lib::MQBACF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9817
  function libmqm_sys::lib::MQWI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10144
  function libmqm_sys::lib::MQCOPY_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9890
  function libmqm_sys::lib::MQLDAP_AUTHORMD_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9963
  function libmqm_sys::lib::MQQA_PUT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10036
  function libmqm_sys::lib::MQS_AVAIL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10109
  function libmqm_sys::lib::MQCFR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9855
  function libmqm_sys::lib::MQFUN_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9928
  function libmqm_sys::lib::MQNHATYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10001
  function libmqm_sys::lib::MQRT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10074
  function libmqm_sys::lib::MQBL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9820
  function libmqm_sys::lib::MQXACT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10147
  function libmqm_sys::lib::MQCRC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9893
  function libmqm_sys::lib::MQLR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9966
  function libmqm_sys::lib::MQQFS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10039
  function libmqm_sys::lib::MQS_STATUS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10112
  function libmqm_sys::lib::MQCFT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9858
  function libmqm_sys::lib::MQGUR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9931
  function libmqm_sys::lib::MQNSH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10004
  function libmqm_sys::lib::MQSCOPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10077
  function libmqm_sys::lib::MQBNO_BALTYPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9823
  function libmqm_sys::lib::MQXDR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10150
  function libmqm_sys::lib::MQCSRV_DLQ_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9896
  function libmqm_sys::lib::MQMCAS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9969
  function libmqm_sys::lib::MQQMFAC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10042
  function libmqm_sys::lib::MQTA_PUB_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10115
  function libmqm_sys::lib::MQCHAD_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9861
  function libmqm_sys::lib::MQHC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9934
  function libmqm_sys::lib::MQOM_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10007
  function libmqm_sys::lib::MQSECCOMM_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10080
  function libmqm_sys::lib::MQBO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9826
  function libmqm_sys::lib::MQXF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10153
  function libmqm_sys::lib::MQCTLO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9899
  function libmqm_sys::lib::MQMCEV_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9972
  function libmqm_sys::lib::MQQMSTA_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10045
  function libmqm_sys::lib::MQTCPSTACK_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10118
  function libmqm_sys::lib::MQCHLA_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9864
  function libmqm_sys::lib::MQHSTATE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9937
  function libmqm_sys::lib::MQOPMODE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10010
  function libmqm_sys::lib::MQSECSW_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10083
  function libmqm_sys::lib::MQCACF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9829
  function libmqm_sys::lib::MQXR_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10156
  function libmqm_sys::lib::MQDC_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9902
  function libmqm_sys::lib::MQMDEF_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9975
  function libmqm_sys::lib::MQQSGD_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10048
  function libmqm_sys::lib::MQTOPT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10121
  function libmqm_sys::lib::MQCHSH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9867
  function libmqm_sys::lib::MQIAMO64_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9940
  function libmqm_sys::lib::MQOTEL_TRACE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10013
  function libmqm_sys::lib::MQSEL_ALL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10086
  function libmqm_sys::lib::MQCAFTY_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9832
  function libmqm_sys::lib::MQZAO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10159
  function libmqm_sys::lib::MQDISCONNECT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9905
  function libmqm_sys::lib::MQMEDIMGLOGLN_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9978
  function libmqm_sys::lib::MQQSOT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10051
  function libmqm_sys::lib::MQTSCOPE_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10124
  function libmqm_sys::lib::MQCHS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9870
  function libmqm_sys::lib::MQIAMO_MONITOR_FLAGS_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9943
  function libmqm_sys::lib::MQPA_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10016
  function libmqm_sys::lib::MQSO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10089
  function libmqm_sys::lib::MQCAUT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9835
  function libmqm_sys::lib::MQZID_AUTHORITY_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10162
  function libmqm_sys::lib::MQDMHO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9908
  function libmqm_sys::lib::MQMHBO_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9981
  function libmqm_sys::lib::MQQT_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10054
  function libmqm_sys::lib::MQUCI_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10127
  function libmqm_sys::lib::MQCIH_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9873
  function libmqm_sys::lib::MQIA_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:9946
  function libmqm_sys::lib::MQPL_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/target/debug/build/libmqm-sys-9dbb256a9fb13999/out/bindings.rs:10019
  function libmqm_sys::lib::MQSQQM_STR, previously in file /tmp/.tmpFOYC1E/libmqm-sys/target/semver-checks/local-libmqm_sys-0_8_0-8072c3ccc89306b9/targ