### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.9.0...libmqm-sys-v0.10.0) - 2025-07-05
+
+### Fixed
+
+- MQCBC type ([#116](https://github.com/advantic-au/libmqm-sys/pull/116))
+
+### Other
+
+- type fix for "MQCB_FUNCTION"
+- Bindings Refactor ([#114](https://github.com/advantic-au/libmqm-sys/pull/114))
+
 ## [0.9.0](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.8.0...libmqm-sys-v0.9.0) - 2025-06-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- type fix for "MQCB_FUNCTION"
 - Bindings Refactor ([#114](https://github.com/advantic-au/libmqm-sys/pull/114))
 
 ## [0.9.0](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.8.0...libmqm-sys-v0.9.0) - 2025-06-27

--- a/libmqm-constants/Cargo.toml
+++ b/libmqm-constants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-constants"
-version = "0.8.1"
+version = "0.8.2"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) constant definitions"
 categories = ["external-ffi-bindings", "asynchronous"]
 authors.workspace = true
@@ -72,7 +72,7 @@ mqc_9_4_2_0 = ["libmqm-sys/mqc_9_4_2_0", "mqc_9_4_1_0"]
 mqc_9_4_3_0 = ["libmqm-sys/mqc_9_4_3_0", "mqc_9_4_2_0"]
 
 [dependencies]
-libmqm-sys = { version = "0.9.0", default-features = false, path = "../libmqm-sys" }
+libmqm-sys = { version = "0.10.0", default-features = false, path = "../libmqm-sys" }
 phf = { default-features = false, version = "0.12.1" }
 derive_more = { version = "2.0.1", features = [
     "from",
@@ -83,7 +83,7 @@ derive_more = { version = "2.0.1", features = [
 document-features = { version = "0.2.10", optional = true }
 
 [build-dependencies]
-libmqm-sys = { version = "0.9.0", default-features = false, path = "../libmqm-sys" }
+libmqm-sys = { version = "0.10.0", default-features = false, path = "../libmqm-sys" }
 regex-lite = { version = "0.1.6", optional = true }
 phf_codegen = { version = "0.12.1", optional = true }
 phf_generator = { version = "0.12.1", optional = true }

--- a/libmqm-default/Cargo.toml
+++ b/libmqm-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-default"
-version = "0.9.0"
+version = "0.10.0"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) structure defaults"
 keywords = ["message-queue", "messaging"]
 categories = ["external-ffi-bindings", "asynchronous"]
@@ -12,11 +12,11 @@ rust-version.workspace = true
 build = "build/main.rs"
 
 [dependencies]
-libmqm-sys = { version = "0.9.0", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.10.0", path = "../libmqm-sys", default-features = false }
 document-features = { version = "0.2.10", optional = true }
 
 [build-dependencies]
-libmqm-sys = { version = "0.9.0", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.10.0", path = "../libmqm-sys", default-features = false }
 prettyplease = { version = "0.2.31", optional = true }
 syn = { version = "2.0.90", optional = true, default-features = false, features = [
     "full",

--- a/libmqm-sys/Cargo.toml
+++ b/libmqm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-sys"
-version = "0.9.0"
+version = "0.10.0"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) bindings"
 keywords = ["message-queue", "messaging"]
 categories = ["external-ffi-bindings", "asynchronous"]


### PR DESCRIPTION



## 🤖 New release

* `libmqm-sys`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `libmqm-constants`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `libmqm-default`: 0.9.0 -> 0.10.0 (✓ API compatible changes)

### ⚠ `libmqm-sys` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function libmqm_sys::lib::MQBACK, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3713
  function libmqm_sys::lib::MQBEGIN, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3724
  function libmqm_sys::lib::mqAddStringFilter, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:223
  function libmqm_sys::lib::MQBUFMH, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3745
  function libmqm_sys::lib::mqClearBag, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:283
  function libmqm_sys::lib::mqDeleteBag, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:327
  function libmqm_sys::lib::mqGetBag, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:385
  function libmqm_sys::lib::MQCMIT, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3807
  function libmqm_sys::lib::mqInquireByteStringFilter, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:453
  function libmqm_sys::lib::MQCONNX, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3835
  function libmqm_sys::lib::mqInquireIntegerFilter, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:517
  function libmqm_sys::lib::mqInquireStringFilter, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:590
  function libmqm_sys::lib::MQDISC, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3887
  function libmqm_sys::lib::mqSetByteString, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:655
  function libmqm_sys::lib::MQDLTMP, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3918
  function libmqm_sys::lib::mqSetInteger64, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:720
  function libmqm_sys::lib::MQGET, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3941
  function libmqm_sys::lib::mqSetStringFilter, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:786
  function libmqm_sys::lib::MQOPEN, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4050
  function libmqm_sys::lib::MQSETMP, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4150
  function libmqm_sys::lib::MQSUBRQ, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4212
  function libmqm_sys::lib::MQXEP, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3342
  function libmqm_sys::lib::mqAddByteStringFilter, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:109
  function libmqm_sys::lib::mqAddInteger64, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:163
  function libmqm_sys::lib::mqAddString, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:202
  function libmqm_sys::lib::mqBufferToBag, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:266
  function libmqm_sys::lib::mqCreateBag, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:312
  function libmqm_sys::lib::mqExecute, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:361
  function libmqm_sys::lib::MQCLOSE, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3791
  function libmqm_sys::lib::mqInquireByteString, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:428
  function libmqm_sys::lib::mqInquireInteger64, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:496
  function libmqm_sys::lib::MQCRTMH, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3853
  function libmqm_sys::lib::mqInquireString, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:563
  function libmqm_sys::lib::mqPutBag, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:633
  function libmqm_sys::lib::mqSetInteger, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:700
  function libmqm_sys::lib::mqSetString, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:763
  function libmqm_sys::lib::mqTruncateBag, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:824
  function libmqm_sys::lib::MQPUT, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4072
  function libmqm_sys::lib::MQSET, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4122
  function libmqm_sys::lib::MQSTAT, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4173
  function libmqm_sys::lib::MQXCNVC, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4496
  function libmqm_sys::lib::mqAddBag, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:69
  function libmqm_sys::lib::mqAddInteger, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:145
  function libmqm_sys::lib::mqAddIntegerFilter, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:182
  function libmqm_sys::lib::mqBagToBuffer, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:245
  function libmqm_sys::lib::mqCountItems, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:295
  function libmqm_sys::lib::MQCB, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3770
  function libmqm_sys::lib::mqDeleteItem, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:339
  function libmqm_sys::lib::mqInquireBag, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:406
  function libmqm_sys::lib::MQCONN, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3818
  function libmqm_sys::lib::mqInquireInteger, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:476
  function libmqm_sys::lib::mqInquireItemInfo, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:539
  function libmqm_sys::lib::MQCTL, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3871
  function libmqm_sys::lib::mqPad, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:613
  function libmqm_sys::lib::MQDLTMH, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3899
  function libmqm_sys::lib::mqSetByteStringFilter, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:678
  function libmqm_sys::lib::mqSetIntegerFilter, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:741
  function libmqm_sys::lib::MQINQ, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3968
  function libmqm_sys::lib::mqTrim, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:807
  function libmqm_sys::lib::MQINQMP, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3997
  function libmqm_sys::lib::MQMHBUF, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4026
  function libmqm_sys::lib::MQPUT1, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4096
  function libmqm_sys::lib::MQSUB, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4192
  function libmqm_sys::lib::MQXCLWLN, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3363
  function libmqm_sys::lib::MQXDX, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3380
  function libmqm_sys::lib::MQZEP, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3399
  function libmqm_sys::lib::mqAddByteString, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:88
  function libmqm_sys::lib::mqAddInquiry, previously in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:128

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod libmqm_sys::lib::version, previously in file /tmp/.tmpnGrvul/libmqm-sys/src/bindgen.rs:12
  mod libmqm_sys::lib, previously in file /tmp/.tmpnGrvul/libmqm-sys/src/bindgen.rs:3

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  MQCA_QSG_NAME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3326
  MQIACF_OPEN_INPUT_TYPE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1154
  MQCACF_SYSP_LOG_RBA in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1808
  MQMCP_ALL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2462
  MQCCT_YES in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1437
  MQSIDT_NONE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2091
  MQRC_UNSUPPORTED_PROPERTY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2745
  MQRCCF_EVENTS_DISABLED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:573
  MQIA_AUTO_REORGANIZATION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3399
  MQIACF_SYSP_TYPE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1227
  MQCACF_APPL_FUNCTION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1881
  MQROUTE_ACCUMULATE_IN_MSG in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2535
  MQCSP_CURRENT_VERSION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1510
  MQACH_VERSION_1 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:2926
  MQ_CANCEL_CODE_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2164
  MQRC_SYNCPOINT_NOT_ALLOWED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2818
  MQRCCF_ENCRYPTION_ALG_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:646
  MQIA_INHIBIT_SUB in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3472
  MQIACF_MSG_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1300
  MQCACH_LU_NAME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1954
  MQDMHO_CURRENT_VERSION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1583
  MQCXP_LENGTH_5 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:2999
  MQ_OBJECT_NAME_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2237
  MQCQT_REMOTE_Q in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2891
  MQRCCF_CONFIGURATION_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:719
  MQIA_QMOPT_CONS_CRITICAL_MSGS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3545
  MQIACF_USAGE_OFFLOAD_MSGS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1373
  MQIMMREASON_NONE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2027
  MQSS_SEGMENT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1656
  MQWQR_VERSION_4 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3072
  MQCC_FAILED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2310
  MQNT_NONE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2964
  MQRCCF_NET_PRIORITY_WRONG_TYPE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:792
  MQIA_TRIGGER_INTERVAL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3618
  MQIACF_ARCHIVE_LOG_SIZE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1446
  MQCFSTATUS_NO_BACKUP in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2100
  MQMT_REPLY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1729
  MQXR_TERM in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3145
  MQRC_TRIGGER_DEPTH_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2383
  MQCMDL_LEVEL_921 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3037
  MQCFOP_NOT_EQUAL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:865
  MQSO_ANY_USERID in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3691
  MQS_STATUS_OPEN in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1519
  MQCMDI_SEC_UPPERCASE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2173
  MQENC_RESERVED_MASK in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1802
  MQZAC_CURRENT_VERSION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3218
  MQRC_RECS_PRESENT_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2456
  MQCMD_DEREGISTER_PUBLISHER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:284
  MQPSCLUS_DISABLED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3110
  MQBACF_MQBNO_STRUCT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:938
  MQIACH_KEEP_ALIVE_INTERVAL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1592
  MQQMDT_AUTO_EXP_CLUSTER_SENDER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2246
  MQACTT_USER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1875
  MQZSL_RETURNED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3291
  MQRC_OFFSET_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2529
  MQCMD_START_CMD_SERVER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:357
  MQDC_MANAGED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3183
  MQIAMO_STATS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1011
  MQCD_LENGTH_4 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4422
  MQIACH_DEF_RECONNECT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1665
  MQRT_NSPROC in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2319
  MQMHBO_DELETE_PROPERTIES in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1948
  MQIASY_CONTROL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:40
  MQRC_ITEM_TYPE_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2602
  MQCMD_AMQP_DIAGNOSTICS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:430
  MQCA_AUTH_INFO_NAME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3256
  MQIAMO_LAST_USED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1084
  MQCACF_EVENT_APPL_IDENTITY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1738
  MQCLST_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2392
  MQCBCT_STOP_CALL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1367
  MQPMO_VERSION_3 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2021
  MQRC_UNSUPPORTED_CIPHER_SUITE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2675
  MQRCCF_NOT_REGISTERED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:503
  MQCA_Q_MGR_IDENTIFIER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3329
  MQIACF_OPEN_INQUIRE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1157
  MQCACF_TO_LISTENER_NAME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1811
  MQNSH_ALL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2465
  MQCTES_COMMIT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1440
  MQSMPO_STRUC_ID in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2094
  MQRC_GET_ENABLED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2748
  MQRCCF_FUNCTION_RESTRICTED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:576
  MQIA_BASE_TYPE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3402
  MQIACF_SYSP_MAX_READ_TAPES in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1230
  MQCACF_XQH_PUT_TIME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1884
  MQDELO_LOCAL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2538
  MQCSP_LENGTH_3 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1513
  MQACH_CURRENT_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:2929
  MQ_CHANNEL_DATE_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2167
  MQRC_MCAST_SUB_STATUS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2821
  MQRCCF_POLICY_VERSION_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:649
  MQIA_KEY_REUSE_COUNT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3475
  MQIACF_ORIGINAL_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1303
  MQCACH_LISTENER_NAME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1957
  MQDMHO_NONE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1586
  MQCXP_LENGTH_8 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3002
  MQ_PROCESS_APPL_ID_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2240
  MQQDT_PREDEFINED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2894
  MQRCCF_SEND_FAILED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:722
  MQIA_QMOPT_CONS_REORG_MSGS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3548
  MQIACF_USAGE_TOTAL_BLOCKS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1376
  MQIMMREASON_MOVING in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2030
  MQSEG_ALLOWED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1659
  MQWQR_LENGTH_2 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3075
  MQRC_APPL_FIRST in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2313
  MQNT_AUTH_INFO in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2967
  MQRCCF_SSL_CIPHER_SPEC_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:795
  MQIA_TRIGGER_TYPE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3621
  MQIACF_REUSABLE_LOG_SIZE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1449
  MQCFSTATUS_XES_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2103
  MQMT_MQE_FIELDS_FROM_MQE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1732
  MQXR_SEC_MSG in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3148
  MQRC_TRUNCATED_MSG_ACCEPTED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2386
  MQCMDL_LEVEL_924 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3040
  MQCFOP_NOT_LIKE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:868
  MQSO_FAIL_IF_QUIESCING in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3694
  MQS_STATUS_OPENFAIL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1522
  MQDISCONNECT_IMPLICIT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2176
  MQENC_INTEGER_REVERSED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1805
  MQZAT_INITIAL_CONTEXT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3221
  MQRC_ASID_MISMATCH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2459
  MQCMD_REGISTER_PUBLISHER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:287
  MQQMOPT_ENABLED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3113
  MQIAMO_AVG_BATCH_SIZE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:941
  MQIACH_ALLOC_RETRY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1595
  MQQMFAC_DB2 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2249
  MQAT_CICS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1878
  MQZID_INIT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3294
  MQRC_UOW_NOT_AVAILABLE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2532
  MQCMD_STOP_CHANNEL_INIT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:360
  MQPSPROP_COMPAT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3186
  MQIAMO_SUB_DUR_LOWWATER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1014
  MQCD_LENGTH_7 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4425
  MQIACH_AMQP_KEEP_ALIVE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1668
  MQSCO_Q_MGR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2322
  MQOD_VERSION_1 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1951
  MQIASY_BAG_OPTIONS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:43
  MQRC_CODED_CHAR_SET_ID_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2605
  MQCMD_INQUIRE_APPL_STATUS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:433
  MQCA_AUTO_REORG_START_TIME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3259
  MQIAMO_MONITOR_UNIT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1087
  MQCACF_SUBSCRIPTION_NAME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1741
  MQSUS_YES in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2395
  MQCBCT_EVENT_CALL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1370
  MQPMO_LENGTH_2 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2024
  MQRC_CLIENT_EXIT_LOAD_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2678
  MQRCCF_Q_NAME_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:506
  MQCA_RECIPIENT_DN in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3332
  MQIACF_Q_HANDLE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1160
  MQCACF_LAST_PUT_DATE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1814
  MQLR_MAX in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2468
  MQCFAC_NONE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1443
  MQSMPO_LENGTH_1 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2097
  MQRC_MODULE_ENTRY_NOT_FOUND in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2751
  MQRCCF_COMMAND_LENGTH_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:579
  MQIA_CAP_EXPIRY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3405
  MQIACF_SYSP_OUT_BUFFER_COUNT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1233
  MQCACF_CSP_USER_IDENTIFIER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1887
  MQPUBO_RETAIN_PUBLICATION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2541
  MQCSP_AUTH_USER_ID_AND_PWD in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1516
  MQAXC_VERSION_2 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:2932
  MQ_CHANNEL_TIME_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2170
  MQRC_PRECONN_EXIT_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2824
  MQRCCF_CHLAUTH_USERSRC_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:652
  MQIA_LDAP_AUTHORMD in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3478
  MQIACF_REASON_CODE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1306
  MQCACH_LISTENER_START_TIME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1960
  MQDMPO_CURRENT_VERSION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1589
  MQXR2_PUT_WITH_DEF_ACTION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3005
  MQ_PROCESS_NAME_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2243
  MQQDT_SHARED_DYNAMIC in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2897
  MQRCCF_CONNECTION_CLOSED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:725
  MQIA_QMOPT_CSMT_ON_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3551
  MQIACF_USAGE_WAIT_RATE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1379
  MQIMMREASON_AWAITS_REPLY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2033
  MQIIH_STRUC_ID in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1662
  MQWQR_CURRENT_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3078
  MQRC_ALREADY_CONNECTED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2316
  MQCFR_NO in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2970
  MQRCCF_RETAINED_NOT_SUPPORTED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:798
  MQIA_USER_LIST in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3624
  MQIACF_LOG_REDUCTION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1452
  MQCHIDS_NOT_INDOUBT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2106
  MQMT_APPL_FIRST in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1735
  MQXR_AUTO_CLUSSDR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3151
  MQRC_UNKNOWN_OBJECT_NAME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2389
  MQCMDL_LEVEL_931 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3043
  MQCFOP_CONTAINS_GEN in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:871
  MQSO_WILDCARD_TOPIC in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3697
  MQS_AVAIL_NORMAL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1525
  MQEVO_OTHER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2179
  MQENC_DECIMAL_REVERSED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1808
  MQZAD_VERSION_1 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3224
  MQRC_CONN_ID_IN_USE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2462
  MQCMD_BROKER_INTERNAL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:290
  MQRCVTIME_ADD in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3116
  MQIAMO_BACKOUTS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:944
  MQIACH_DISC_RETRY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1598
  MQQMSTA_QUIESCING in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2252
  MQAT_ZOS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1881
  MQZID_TERM_AUTHORITY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3297
  MQRC_GROUP_ID_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2535
  MQCMD_STOP_Q_MGR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:363
  MQRU_PUBLISH_ON_REQUEST in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3189
  MQIAMO_TOPIC_PUTS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1017
  MQCD_LENGTH_10 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:4428
  MQIACH_LAST_USED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1671
  MQSECITEM_MQADMIN in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2325
  MQOD_VERSION_4 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1954
  MQIASY_LAST in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqai.rs:46
  MQRC_WIH_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2608
  MQRCCF_CFH_TYPE_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:436
  MQCA_BASE_Q_NAME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3262
  MQIAMO_MONITOR_HUNDREDTHS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1090
  MQCACF_REG_SUB_IDENTITY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1744
  MQSYNCPOINT_IFPER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2398
  MQCBCT_MC_EVENT_CALL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1373
  MQPMO_SYNCPOINT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2027
  MQRC_SSL_KEY_RESET_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2681
  MQRCCF_INCORRECT_Q in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:509
  MQCA_REPOSITORY_NAME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3335
  MQIACF_CONNECTION_ATTRS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1163
  MQCACF_LAST_GET_TIME in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1817
  MQFS_SHARED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2471
  MQCFUNC_MQINQ in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1446
  MQSMPO_SET_PROP_UNDER_CURSOR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2100
  MQRC_HCONN_ASYNC_ACTIVE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2754
  MQRCCF_LISTENER_STARTED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:582
  MQIA_CF_LEVEL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3408
  MQIACF_SYSP_DUAL_ARCHIVE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1236
  MQCACF_APPL_IMMOVABLE_DATE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1890
  MQPUBO_IS_RETAINED_PUBLICATION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2544
  MQCNO_VERSION_1 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1519
  MQAXC_LENGTH_2 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:2935
  MQ_AMQP_CLIENT_ID_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2173
  MQRC_CHANNEL_BLOCKED_WARNING in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2827
  MQRCCF_CHLAUTH_NOT_FOUND in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:655
  MQIA_LISTENER_PORT_NUMBER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3481
  MQIACF_UNRECORDED_ACTIVITIES in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1309
  MQCACH_REMOTE_VERSION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1963
  MQDMPO_DEL_FIRST in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1592
  MQXR2_USE_AGENT_BUFFER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3008
  MQ_PUT_APPL_NAME_LENGTH in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2246
  MQQA_PUT_INHIBITED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2900
  MQRCCF_LISTENER_NOT_STARTED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:728
  MQIA_QMOPT_LOG_CRITICAL_MSGS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3554
  MQIACF_SMDS_AVAIL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1382
  MQAS_STARTED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2036
  MQIIH_LENGTH_1 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1665
  MQQF_CLWL_USEQ_LOCAL in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3081
  MQRC_BUFFER_LENGTH_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2319
  MQCFCONLOS_TERMINATE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2973
  MQRCCF_NHA_NOT_AVAILABLE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:801
  MQIA_XR_CAPABILITY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3627
  MQIACF_APPL_INFO_ATTRS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1455
  MQCHLD_DEFAULT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2109
  MQFB_NONE in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1738
  MQXR_CLWL_PUT in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3154
  MQRC_WAIT_INTERVAL_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2392
  MQCMDL_LEVEL_934 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3046
  MQCFT_COMMAND in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:874
  MQSO_NO_READ_AHEAD in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3700
  MQBPLOCATION_BELOW in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1528
  MQEVO_MSG in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2182
  MQENC_FLOAT_IEEE_REVERSED in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1811
  MQZAD_LENGTH_1 in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3227
  MQRC_DUPLICATE_RECOV_COORD in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:2465
  MQCMD_RESUME_Q_MGR_CLUSTER in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:293
  MQRECORDING_Q in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:3119
  MQIAMO_BROWSE_MIN_BYTES in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:947
  MQIACH_MSG_COMPRESSION in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:1601
  MQQMT_REPOSITORY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/pcf.rs:2255
  MQAT_DOS in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/mqi.rs:1884
  MQZID_DELETE_AUTHORITY in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd9a8b86803b3/out/exits.rs:3300
  MQRC_SRC_ENV_ERROR in file /tmp/.tmpnGrvul/libmqm-sys/target/semver-checks/local-libmqm_sys-0_9_0-e6cdded3774de55b/target/debug/build/libmqm-sys-561bd