### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.10.0...libmqm-sys-v0.10.1) - 2025-07-06
+
+### Fixed
+
+- feature gate MQ 9.4.3 constants
+- MQDCC should not be gated
+
+### Other
+
+- MQ client 9.4.3.0 Linux ppc64le
+- MQ client 9.4.3.0 Linux s390x
+- MQ client 9.4.3.0 macOS ARM64
+- MQ client 9.4.3.0 Linux ARM64
+- MQ client 9.4.3.0 Windows X64
+
 ## [0.10.0](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.9.0...libmqm-sys-v0.10.0) - 2025-07-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- feature gate MQ 9.4.3 constants
-- MQDCC should not be gated
-
-### Other
-
-- MQ client 9.4.3.0 Linux ppc64le
-- MQ client 9.4.3.0 Linux s390x
-- MQ client 9.4.3.0 macOS ARM64
-- MQ client 9.4.3.0 Linux ARM64
-- MQ client 9.4.3.0 Windows X64
+- Feature gate MQ 9.4.3 constants
+- Removed feature gates for MQDCC
 
 ## [0.10.0](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.9.0...libmqm-sys-v0.10.0) - 2025-07-05
 

--- a/libmqm-constants/Cargo.toml
+++ b/libmqm-constants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-constants"
-version = "0.8.2"
+version = "0.8.3"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) constant definitions"
 categories = ["external-ffi-bindings", "asynchronous"]
 authors.workspace = true
@@ -72,7 +72,7 @@ mqc_9_4_2_0 = ["libmqm-sys/mqc_9_4_2_0", "mqc_9_4_1_0"]
 mqc_9_4_3_0 = ["libmqm-sys/mqc_9_4_3_0", "mqc_9_4_2_0"]
 
 [dependencies]
-libmqm-sys = { version = "0.10.0", default-features = false, path = "../libmqm-sys" }
+libmqm-sys = { version = "0.10.1", default-features = false, path = "../libmqm-sys" }
 phf = { default-features = false, version = "0.12.1" }
 derive_more = { version = "2.0.1", features = [
     "from",
@@ -83,7 +83,7 @@ derive_more = { version = "2.0.1", features = [
 document-features = { version = "0.2.10", optional = true }
 
 [build-dependencies]
-libmqm-sys = { version = "0.10.0", default-features = false, path = "../libmqm-sys" }
+libmqm-sys = { version = "0.10.1", default-features = false, path = "../libmqm-sys" }
 regex-lite = { version = "0.1.6", optional = true }
 phf_codegen = { version = "0.12.1", optional = true }
 phf_generator = { version = "0.12.1", optional = true }

--- a/libmqm-default/Cargo.toml
+++ b/libmqm-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-default"
-version = "0.10.0"
+version = "0.10.1"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) structure defaults"
 keywords = ["message-queue", "messaging"]
 categories = ["external-ffi-bindings", "asynchronous"]
@@ -12,11 +12,11 @@ rust-version.workspace = true
 build = "build/main.rs"
 
 [dependencies]
-libmqm-sys = { version = "0.10.0", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.10.1", path = "../libmqm-sys", default-features = false }
 document-features = { version = "0.2.10", optional = true }
 
 [build-dependencies]
-libmqm-sys = { version = "0.10.0", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.10.1", path = "../libmqm-sys", default-features = false }
 prettyplease = { version = "0.2.31", optional = true }
 syn = { version = "2.0.90", optional = true, default-features = false, features = [
     "full",

--- a/libmqm-sys/Cargo.toml
+++ b/libmqm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-sys"
-version = "0.10.0"
+version = "0.10.1"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) bindings"
 keywords = ["message-queue", "messaging"]
 categories = ["external-ffi-bindings", "asynchronous"]


### PR DESCRIPTION



## 🤖 New release

* `libmqm-sys`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `libmqm-constants`: 0.8.2 -> 0.8.3 (✓ API compatible changes)
* `libmqm-default`: 0.10.0 -> 0.10.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `libmqm-sys`

<blockquote>

## [0.10.1](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.10.0...libmqm-sys-v0.10.1) - 2025-07-06

### Fixed

- feature gate MQ 9.4.3 constants
- MQDCC should not be gated

### Other

- MQ client 9.4.3.0 Linux ppc64le
- MQ client 9.4.3.0 Linux s390x
- MQ client 9.4.3.0 macOS ARM64
- MQ client 9.4.3.0 Linux ARM64
- MQ client 9.4.3.0 Windows X64
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).