### PR TITLE
dependency update october 2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           shared-key: "build"
       - uses: taiki-e/install-action@2cab843126c0d8cf950bf55f4e9b8413f70f553f # v2.54.1
@@ -68,7 +68,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           shared-key: "build"
       - uses: taiki-e/install-action@2cab843126c0d8cf950bf55f4e9b8413f70f553f # v2.54.1
@@ -251,7 +251,7 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           shared-key: "build"
       - name: Refresh pregenerated content

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           client-version: ${{ matrix.version.client-version }}
       - name: Install rust stable
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
@@ -64,7 +64,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
@@ -114,12 +114,12 @@ jobs:
         id: mq-client
       # Re-resolve Cargo.lock with minimal versions
       - name: Install rust nightly
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: nightly # -Z option only available on nightly
       - run: cargo generate-lockfile -Z minimal-versions
       # Now verify that `cargo check` works with respect to the oldest possible
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      - uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: 1.82
       - name: Check code
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      - uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: nightly
       - uses: taiki-e/install-action@2cab843126c0d8cf950bf55f4e9b8413f70f553f # v2.54.1
@@ -248,7 +248,7 @@ jobs:
         with:
           client-version: ${{ steps.mq_version_pregen.outputs.client-version }}
       - name: Install rust stable
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           shared-key: "build"
-      - uses: taiki-e/install-action@2cab843126c0d8cf950bf55f4e9b8413f70f553f # v2.54.1
+      - uses: taiki-e/install-action@e43a5023a747770bfcb71ae048541a681714b951 # v2.62.33
         with:
           tool: nextest
       - name: Test
@@ -71,7 +71,7 @@ jobs:
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           shared-key: "build"
-      - uses: taiki-e/install-action@2cab843126c0d8cf950bf55f4e9b8413f70f553f # v2.54.1
+      - uses: taiki-e/install-action@e43a5023a747770bfcb71ae048541a681714b951 # v2.62.33
         with:
           tool: cargo-hack
       - name: Install MQ client
@@ -126,7 +126,7 @@ jobs:
         run: cargo check --locked --all-features
         env:
           MQ_HOME: ${{ steps.mq-client.outputs.client-install-path }}
-      - uses: taiki-e/install-action@2cab843126c0d8cf950bf55f4e9b8413f70f553f # v2.54.1
+      - uses: taiki-e/install-action@e43a5023a747770bfcb71ae048541a681714b951 # v2.62.33
         with:
           tool: nextest
       - name: Test
@@ -146,7 +146,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:
           toolchain: nightly
-      - uses: taiki-e/install-action@2cab843126c0d8cf950bf55f4e9b8413f70f553f # v2.54.1
+      - uses: taiki-e/install-action@e43a5023a747770bfcb71ae048541a681714b951 # v2.62.33
         with:
           tool: cargo-docs-rs
       - run: cargo docs-rs -p libmqm-sys --target x86_64-unknown-linux-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             feature: mqc_9_4_3_0
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install MQ client
@@ -60,7 +60,7 @@ jobs:
         toolchain: [ stable, beta ]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install rust ${{ matrix.toolchain }}
@@ -107,7 +107,7 @@ jobs:
   minimum:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: advantic-au/action-mq-client@stable
@@ -140,7 +140,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
@@ -169,7 +169,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Determine MQ version
@@ -236,7 +236,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Determine MQ version

--- a/.github/workflows/pregen-command.yml
+++ b/.github/workflows/pregen-command.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       # Checkout the pull request branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: true
           fetch-depth: 0
@@ -75,7 +75,7 @@ jobs:
       contents: write
     steps:
       # Checkout the pull request branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: true
           fetch-depth: 0
@@ -151,7 +151,7 @@ jobs:
     needs: [ pregen, pregen_arch ]
     if: ${{ always() }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: true
           fetch-depth: 0

--- a/.github/workflows/pregen-command.yml
+++ b/.github/workflows/pregen-command.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           client-version: ${{ steps.mq_version_pregen.outputs.client-version }}
       - name: Install rust stable
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8

--- a/.github/workflows/pregen-command.yml
+++ b/.github/workflows/pregen-command.yml
@@ -40,7 +40,7 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           shared-key: "build"
       - name: Run build and refresh generated source code

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: advantic-au/action-mq-client@stable
         id: mq-client
       - name: Install rust stable
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: stable
       - name: Run release-plz
@@ -56,7 +56,7 @@ jobs:
       - uses: advantic-au/action-mq-client@stable
         id: mq-client
       - name: Install rust stable
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: stable
       - name: Run release-plz

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           toolchain: stable
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@8724d33cd97b8295051102e2e19ca592962238f5 # v0.5
+        uses: MarcoIeni/release-plz-action@d529f731ae3e89610ada96eda34e5c6ba3b12214 # v0.5
         with:
           command: release
         env:
@@ -60,7 +60,7 @@ jobs:
         with:
           toolchain: stable
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@8724d33cd97b8295051102e2e19ca592962238f5 # v0.5
+        uses: MarcoIeni/release-plz-action@d529f731ae3e89610ada96eda34e5c6ba3b12214 # v0.5
         with:
           command: release-pr
         env:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: true
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: true
           fetch-depth: 0

--- a/.github/workflows/semver-command.yml
+++ b/.github/workflows/semver-command.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           shared-key: "build"
       - name: Check semver

--- a/.github/workflows/semver-command.yml
+++ b/.github/workflows/semver-command.yml
@@ -17,7 +17,7 @@ jobs:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
       - name: Install rust stable
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8

--- a/.github/workflows/semver-command.yml
+++ b/.github/workflows/semver-command.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       # Checkout the pull request branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           token: ${{ secrets.SCD }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install uv

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@445689ea25e0de0a23313031f5fe577c74ae45a1 # v6.0
+        uses: astral-sh/setup-uv@2ddd2b9cb38ad8efd50337e8ab201519a34c9f24 # v6.0
       - name: Install zizmor
         run: uv tool install zizmor
       - name: zizmor static analysis check

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@2ddd2b9cb38ad8efd50337e8ab201519a34c9f24 # v6.0
+        uses: astral-sh/setup-uv@2ddd2b9cb38ad8efd50337e8ab201519a34c9f24 # v7.1
       - name: Install zizmor
         run: uv tool install zizmor
       - name: zizmor static analysis check

--- a/libmqm-constants/Cargo.toml
+++ b/libmqm-constants/Cargo.toml
@@ -86,7 +86,7 @@ document-features = { version = "0.2.10", optional = true }
 libmqm-sys = { version = "0.10.1", default-features = false, path = "../libmqm-sys" }
 regex-lite = { version = "0.1.6", optional = true }
 phf_codegen = { version = "0.12.1", optional = true }
-phf_generator = { version = "0.12.1", optional = true }
+phf_generator = { version = "0.13.1", optional = true }
 prettyplease = { version = "0.2.31", optional = true }
 syn = { version = "2.0.90", optional = true, default-features = false, features = [
     "full",

--- a/libmqm-constants/Cargo.toml
+++ b/libmqm-constants/Cargo.toml
@@ -85,7 +85,7 @@ document-features = { version = "0.2.10", optional = true }
 [build-dependencies]
 libmqm-sys = { version = "0.10.1", default-features = false, path = "../libmqm-sys" }
 regex-lite = { version = "0.1.6", optional = true }
-phf_codegen = { version = "0.12.1", optional = true }
+phf_codegen = { version = "0.13.1", optional = true }
 phf_generator = { version = "0.12.1", optional = true }
 prettyplease = { version = "0.2.31", optional = true }
 syn = { version = "2.0.90", optional = true, default-features = false, features = [

--- a/libmqm-constants/Cargo.toml
+++ b/libmqm-constants/Cargo.toml
@@ -85,8 +85,8 @@ document-features = { version = "0.2.10", optional = true }
 [build-dependencies]
 libmqm-sys = { version = "0.10.1", default-features = false, path = "../libmqm-sys" }
 regex-lite = { version = "0.1.6", optional = true }
-phf_codegen = { version = "0.12.1", optional = true }
-phf_generator = { version = "0.12.1", optional = true }
+phf_codegen = { version = "0.13.1", optional = true }
+phf_generator = { version = "0.13.1", optional = true }
 prettyplease = { version = "0.2.31", optional = true }
 syn = { version = "2.0.90", optional = true, default-features = false, features = [
     "full",

--- a/libmqm-constants/Cargo.toml
+++ b/libmqm-constants/Cargo.toml
@@ -73,7 +73,7 @@ mqc_9_4_3_0 = ["libmqm-sys/mqc_9_4_3_0", "mqc_9_4_2_0"]
 
 [dependencies]
 libmqm-sys = { version = "0.10.1", default-features = false, path = "../libmqm-sys" }
-phf = { default-features = false, version = "0.12.1" }
+phf = { default-features = false, version = "0.13.1" }
 derive_more = { version = "2.0.1", features = [
     "from",
     "add",

--- a/libmqm-sys/src/lib.rs
+++ b/libmqm-sys/src/lib.rs
@@ -103,7 +103,7 @@ files.
 
  */
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, doc(cfg_hide(feature = "bindgen")))]
+#![cfg_attr(docsrs, doc(hide(feature = "bindgen")))]
 
 #[cfg(feature = "bindgen")]
 #[rustfmt::skip]

--- a/libmqm-sys/src/lib.rs
+++ b/libmqm-sys/src/lib.rs
@@ -103,7 +103,6 @@ files.
 
  */
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, doc(hide(feature = "bindgen")))]
 
 #[cfg(feature = "bindgen")]
 #[rustfmt::skip]

--- a/libmqm-sys/src/lib.rs
+++ b/libmqm-sys/src/lib.rs
@@ -102,7 +102,7 @@ from the MQ library header files. Accuracy of the documentation is dependent on 
 files.
 
  */
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg, doc_cfg_hide))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, doc(cfg_hide(feature = "bindgen")))]
 
 #[cfg(feature = "bindgen")]


### PR DESCRIPTION
- **build(deps): bump actions/checkout from 4 to 5**
- **build(deps): bump Swatinem/rust-cache from 2.7.8 to 2.8.1**
- **build(deps): bump dtolnay/rust-toolchain**
- **build(deps): bump github/codeql-action from 3 to 4**
- **build(deps): bump MarcoIeni/release-plz-action from 0.5.108 to 0.5.118**
- **build(deps): bump taiki-e/install-action from 2.54.1 to 2.62.33**
- **build(deps): bump astral-sh/setup-uv from 6.3.0 to 7.1.1**
