### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,28 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- MQ client 9.4.5.0 Linux ppc64le
-- MQ client 9.4.5.0 Linux s390x
-- MQ client 9.4.5.0 macOS ARM64
-- MQ client 9.4.5.0 Linux ARM64
-- MQ client 9.4.5.0 Windows X64
-- MQ 9.4.5 generated files (x64)
-- IBM MQ 9.4.5
+- IBM MQ 9.4.4 and 9.4.5
 - Bump dependencies
 - Addressed clippy warnings / errors
-- MQ client 9.4.4.0 Linux ppc64le
-- MQ client 9.4.4.0 Linux s390x
-- MQ client 9.4.4.0 macOS ARM64
-- MQ client 9.4.4.0 Linux ARM64
-- MQ client 9.4.4.0 Linux X64
-- MQ client 9.4.4.0 Windows X64
-- fixed docsrs generation
-- renamed cfg_hide to hide
-- removed doc_cfg_hide and doc_auto_cfg
-- MQ 9.4.4
-- *(deps)* update phf_generator requirement from 0.12.1 to 0.13.1
-- *(deps)* update phf_codegen requirement from 0.12.1 to 0.13.1
-- *(deps)* update phf requirement from 0.12.1 to 0.13.1
 
 ## [0.10.1](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.10.0...libmqm-sys-v0.10.1) - 2025-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.10.1...libmqm-sys-v0.10.2) - 2026-02-09
+
+### Other
+
+- MQ client 9.4.5.0 Linux ppc64le
+- MQ client 9.4.5.0 Linux s390x
+- MQ client 9.4.5.0 macOS ARM64
+- MQ client 9.4.5.0 Linux ARM64
+- MQ client 9.4.5.0 Windows X64
+- MQ 9.4.5 generated files (x64)
+- IBM MQ 9.4.5
+- Bump dependencies
+- Addressed clippy warnings / errors
+- MQ client 9.4.4.0 Linux ppc64le
+- MQ client 9.4.4.0 Linux s390x
+- MQ client 9.4.4.0 macOS ARM64
+- MQ client 9.4.4.0 Linux ARM64
+- MQ client 9.4.4.0 Linux X64
+- MQ client 9.4.4.0 Windows X64
+- fixed docsrs generation
+- renamed cfg_hide to hide
+- removed doc_cfg_hide and doc_auto_cfg
+- MQ 9.4.4
+- *(deps)* update phf_generator requirement from 0.12.1 to 0.13.1
+- *(deps)* update phf_codegen requirement from 0.12.1 to 0.13.1
+- *(deps)* update phf requirement from 0.12.1 to 0.13.1
+
 ## [0.10.1](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.10.0...libmqm-sys-v0.10.1) - 2025-07-06
 
 ### Fixed

--- a/libmqm-constants/Cargo.toml
+++ b/libmqm-constants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-constants"
-version = "0.8.3"
+version = "0.8.4"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) constant definitions"
 categories = ["external-ffi-bindings", "asynchronous"]
 authors.workspace = true
@@ -77,7 +77,7 @@ mqc_9_4_5_0 = ["libmqm-sys/mqc_9_4_5_0", "mqc_9_4_4_0"]
 
 
 [dependencies]
-libmqm-sys = { version = "0.10.1", default-features = false, path = "../libmqm-sys" }
+libmqm-sys = { version = "0.10.2", default-features = false, path = "../libmqm-sys" }
 phf = { default-features = false, version = "0.13.1" }
 derive_more = { version = "2.0.1", features = [
     "from",
@@ -88,7 +88,7 @@ derive_more = { version = "2.0.1", features = [
 document-features = { version = "0.2.10", optional = true }
 
 [build-dependencies]
-libmqm-sys = { version = "0.10.1", default-features = false, path = "../libmqm-sys" }
+libmqm-sys = { version = "0.10.2", default-features = false, path = "../libmqm-sys" }
 regex-lite = { version = "0.1.6", optional = true }
 phf_codegen = { version = "0.13.1", optional = true }
 phf_generator = { version = "0.13.1", optional = true }

--- a/libmqm-constants/Cargo.toml
+++ b/libmqm-constants/Cargo.toml
@@ -72,7 +72,7 @@ mqc_9_4_2_0 = ["libmqm-sys/mqc_9_4_2_0", "mqc_9_4_1_0"]
 mqc_9_4_3_0 = ["libmqm-sys/mqc_9_4_3_0", "mqc_9_4_2_0"]
 ## Minimum MQ client version 9.4.4.0
 mqc_9_4_4_0 = ["libmqm-sys/mqc_9_4_4_0", "mqc_9_4_3_0"]
-## Minimum MQ client version 9.4.4.0
+## Minimum MQ client version 9.4.5.0
 mqc_9_4_5_0 = ["libmqm-sys/mqc_9_4_5_0", "mqc_9_4_4_0"]
 
 

--- a/libmqm-default/Cargo.toml
+++ b/libmqm-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-default"
-version = "0.10.1"
+version = "0.10.2"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) structure defaults"
 keywords = ["message-queue", "messaging"]
 categories = ["external-ffi-bindings", "asynchronous"]
@@ -12,11 +12,11 @@ rust-version.workspace = true
 build = "build/main.rs"
 
 [dependencies]
-libmqm-sys = { version = "0.10.1", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.10.2", path = "../libmqm-sys", default-features = false }
 document-features = { version = "0.2.10", optional = true }
 
 [build-dependencies]
-libmqm-sys = { version = "0.10.1", path = "../libmqm-sys", default-features = false }
+libmqm-sys = { version = "0.10.2", path = "../libmqm-sys", default-features = false }
 prettyplease = { version = "0.2.31", optional = true }
 syn = { version = "2.0.90", optional = true, default-features = false, features = [
     "full",

--- a/libmqm-sys/Cargo.toml
+++ b/libmqm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmqm-sys"
-version = "0.10.1"
+version = "0.10.2"
 description = "IBM® MQ Interface (MQI), Programmable Command Format (PCF) and MQ Administration Interface (MQAI) bindings"
 keywords = ["message-queue", "messaging"]
 categories = ["external-ffi-bindings", "asynchronous"]


### PR DESCRIPTION



## 🤖 New release

* `libmqm-sys`: 0.10.1 -> 0.10.2 (✓ API compatible changes)
* `libmqm-constants`: 0.8.3 -> 0.8.4 (✓ API compatible changes)
* `libmqm-default`: 0.10.1 -> 0.10.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `libmqm-sys`

<blockquote>

## [0.10.2](https://github.com/advantic-au/libmqm-sys/compare/libmqm-sys-v0.10.1...libmqm-sys-v0.10.2) - 2026-02-09

### Other

- MQ client 9.4.5.0 Linux ppc64le
- MQ client 9.4.5.0 Linux s390x
- MQ client 9.4.5.0 macOS ARM64
- MQ client 9.4.5.0 Linux ARM64
- MQ client 9.4.5.0 Windows X64
- MQ 9.4.5 generated files (x64)
- IBM MQ 9.4.5
- Bump dependencies
- Addressed clippy warnings / errors
- MQ client 9.4.4.0 Linux ppc64le
- MQ client 9.4.4.0 Linux s390x
- MQ client 9.4.4.0 macOS ARM64
- MQ client 9.4.4.0 Linux ARM64
- MQ client 9.4.4.0 Linux X64
- MQ client 9.4.4.0 Windows X64
- fixed docsrs generation
- renamed cfg_hide to hide
- removed doc_cfg_hide and doc_auto_cfg
- MQ 9.4.4
- *(deps)* update phf_generator requirement from 0.12.1 to 0.13.1
- *(deps)* update phf_codegen requirement from 0.12.1 to 0.13.1
- *(deps)* update phf requirement from 0.12.1 to 0.13.1
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).